### PR TITLE
Remove .less Comma

### DIFF
--- a/index.less
+++ b/index.less
@@ -11,7 +11,7 @@ atom-text-editor, :host {
     background-color: #264F78;
   }
 
-  .line-number.cursor-line-no-selection,
+  .line-number.cursor-line-no-selection
   {
     background-color: #0F0F0F;
   }


### PR DESCRIPTION
Remove comma on line 14 causing cursor to show off center of character in Atom.
