### PR TITLE
Fix cursor offset in editor window.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.1 - Fix cursor offset
+* The cursor was offset to the right of its actual position due to the left margin having a thickness.
 ## 2.0.0 - Color Update
 * Color scheme was incorrect due my own settings being incorrect in Visual Studio. Updated to defalt colours o Visual Studio Dark theme.
 ## 1.1.0 - First Release

--- a/index.less
+++ b/index.less
@@ -11,18 +11,16 @@ atom-text-editor, :host {
     background-color: #264F78;
   }
 
-  .line-number.cursor-line-no-selection,
-  {
+  .line-number.cursor-line-no-selection {
     background-color: #0F0F0F;
   }
 
-  .line.cursor-line
-  {
+  .line.cursor-line {
     background-color: #0F0F0F;
     border-color: #282828;
-    border-width: 3px;
+    border-width: 3px 0 3px 0;
     border-style: solid;
-    margin:-3px;
+    margin: -3px 0 -3px 0;
   }
 
   .line-number{

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Visual-Studio-2015-Dark-Theme",
   "theme": "syntax",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "This is as close as I can get to a replica of the Visual Studio 2015's Dark theme in Atom.",
   "keywords": [
     "syntax",


### PR DESCRIPTION
In the editor window, the cursor was previously offset to the right about half a character's width.

This was caused by the current line having a left margin, so I removed that to correct the issue. I also fixed a small syntax error where there was an extra comma. There are no visual changes, other than the position of the cursor. 
