### PR TITLE
Various small improvements

### DIFF
--- a/index.less
+++ b/index.less
@@ -16,7 +16,13 @@ atom-text-editor, :host {
     background-color: #0F0F0F;
   }
 
+  .meta.directive {
+    color: #9B9B9B;
 
+    .name {
+      color: #DCDCDC;
+    }
+  }
 
   .line.cursor-line
   {
@@ -41,7 +47,7 @@ atom-text-editor, :host {
     color: #F1F2F3;
   }
 
-  .variable, .support.other.variable, .string.other.link, .entity.name.tag, .entity.name.filename.find-in-files {
+  .support.other.variable, .string.other.link, .entity.name.tag, .entity.name.filename.find-in-files {
     color: #569CD6;
   }
 
@@ -49,8 +55,8 @@ atom-text-editor, :host {
     color: #D69D85;
   }
 
-  .constant.numeric, .support.constant, .punctuation.section.embedded, .keyword.other.unit, .constant.character.escape {
-    color: #B5B56E;
+  .constant.numeric, .support.constant, .punctuation.section.embedded, .keyword.other.unit, .entity.name.interface, .meta.generic.type.specifier > .entity.name  {
+    color: #B8D7A3;
   }
 
   .entity.name.class, .entity.name.type.class, .support.type, .support.class {
@@ -86,5 +92,25 @@ atom-text-editor, :host {
 
   .invisible-character {
     color: #2B91AF;
+  }
+
+  .markup.underline {
+    text-decoration: underline;
+  }
+
+  .markup.hyperlink {
+    color: #569AD6;
+  }
+
+  .comment.block.documentation {
+    color: #608B4E;
+
+    .meta.tag.xml, .punctuation.tag, .localname.xml {
+      color: #608B4E;
+    }
+
+    .entity.attribute-name, .string.quoted.double.xml, .punctuation.definition.string.xml {
+      color: #DCDCDC;
+    }
   }
 }


### PR DESCRIPTION
This PR fixes up a few things;

1. Variable names now white not blue
2. Hyperlinked strings now underlined and blue
3. Xml doc comments now green text except white for attribute name and string
4. Constant numeric color correction (was slightly off)

Additionally it also adds support for the improved C# highlighting coming in the next Atom beta;

1. Region directives now colored as per VS (Grey + white)
2. Generic type specifiers now colored light green (like constants)
3. Interfaces now colored light green (like constants)

Screenshot showing this theme along with latest C# language;

![image](https://cloud.githubusercontent.com/assets/118951/21574330/00ceabaa-cea6-11e6-92e6-f883ebf23bd5.png)
